### PR TITLE
chore: bump deps in ra-verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -84,18 +84,19 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1"
-version = "0.17.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a10032de7d9e6f21c3f1cb1c9c0f94cf30ef67f38310588fe6cfa53e0d3f0"
+checksum = "df42c2b01c5e1060b8281f67b4e5fb858260694916a667345a7305cd11e5dbfa"
 dependencies = [
  "asn1_derive",
+ "itoa",
 ]
 
 [[package]]
 name = "asn1_derive"
-version = "0.17.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df30ecdcaf8338675a1413460a1b11df89789e1fcc6a10dc52f6e38b6982aa2"
+checksum = "cdccf849b54365e3693e9a90ad36e4482b79937e6373ac8e2cf229c985187b21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1078,7 +1079,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1144,7 +1145,7 @@ dependencies = [
  "uuid",
  "x509-cert",
  "x509-verify",
- "zerocopy",
+ "zerocopy 0.8.26",
 ]
 
 [[package]]
@@ -1851,7 +1852,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive 0.8.26",
 ]
 
 [[package]]
@@ -1859,6 +1869,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/ra-verify/Cargo.toml
+++ b/lib/ra-verify/Cargo.toml
@@ -12,11 +12,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.125", features = ["raw_value"]}
 hex = { version = "0.4.3", features = ["serde"]}
 chrono = { version = "0.4.38", features = ["serde"] }
-asn1 = "0.17.0"
+asn1 = "0.22.0"
 uuid = "1.10.0"
 
 # IO
-zerocopy = { version = "0.7.34", features = ["derive"] }
+zerocopy = { version = "0.8.26", features = ["derive"] }
 bitflags = "2.3.3"
 
 # Rustcrypto ecosystem

--- a/lib/ra-verify/src/lib.rs
+++ b/lib/ra-verify/src/lib.rs
@@ -13,7 +13,7 @@ use types::tcb_info::TcbInfo;
 use types::{INTEL_QE_VENDOR_ID, INTEL_ROOT_CA};
 use utils::Expireable;
 use uuid::Uuid;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::types::sgx_x509::SgxPckExtension;
 use crate::types::tcb_info::{TcbLevel, TcbStatus};

--- a/lib/ra-verify/src/types/quote.rs
+++ b/lib/ra-verify/src/types/quote.rs
@@ -106,8 +106,8 @@ impl TryFrom<[u8; std::mem::size_of::<SgxQuoteBody>()]> for SgxQuoteBody {
     type Error = Error;
 
     fn try_from(bytes: [u8; std::mem::size_of::<SgxQuoteBody>()]) -> Result<Self> {
-        let quote_body =
-            <Self as zerocopy::FromBytes>::read_from_bytes(&bytes).expect("size was already checked");
+        let quote_body = <Self as zerocopy::FromBytes>::read_from_bytes(&bytes)
+            .expect("size was already checked");
         if quote_body.version.get() != QUOTE_V3 {
             return Err(anyhow!(format!(
                 "unsupported SGX quote version: {}",

--- a/lib/ra-verify/src/types/report.rs
+++ b/lib/ra-verify/src/types/report.rs
@@ -1,7 +1,7 @@
 // Adapted from: https://github.com/signalapp/libsignal/
 
 use bitflags::bitflags;
-use zerocopy::{little_endian, AsBytes, FromBytes, FromZeroes};
+use zerocopy::{little_endian, IntoBytes, FromBytes};
 
 // Inline header file references are paths from the root of the repository tree.
 // https://github.com/openenclave/openenclave/tree/v0.17.7
@@ -12,7 +12,7 @@ const SGX_HASH_SIZE: usize = 32;
 
 pub type MREnclave = [u8; SGX_HASH_SIZE];
 
-#[derive(Debug, FromBytes, FromZeroes, AsBytes)]
+#[derive(Debug, FromBytes, IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 // sgx_report_body_t
 pub struct SgxReportBody {

--- a/lib/ra-verify/src/types/report.rs
+++ b/lib/ra-verify/src/types/report.rs
@@ -1,7 +1,7 @@
 // Adapted from: https://github.com/signalapp/libsignal/
 
 use bitflags::bitflags;
-use zerocopy::{little_endian, IntoBytes, FromBytes};
+use zerocopy::{little_endian, FromBytes, IntoBytes};
 
 // Inline header file references are paths from the root of the repository tree.
 // https://github.com/openenclave/openenclave/tree/v0.17.7

--- a/lib/ra-verify/src/utils.rs
+++ b/lib/ra-verify/src/utils.rs
@@ -5,7 +5,7 @@ use x509_cert::crl::CertificateList;
 
 pub mod u32_hex {
     use serde::Serializer;
-    use zerocopy::AsBytes;
+    use zerocopy::IntoBytes;
 
     use crate::types::UInt32LE;
 
@@ -128,7 +128,7 @@ impl Expireable for Vec<CertificateInner> {
 ///
 /// Returns `None` and leaves `bytes` unchanged if it isn't long enough.
 pub fn read_from_bytes<T: zerocopy::FromBytes>(bytes: &mut &[u8]) -> Option<T> {
-    let front = T::read_from_prefix(bytes)?;
+    let (front, _) = T::read_from_prefix(bytes).ok()?; // TODO: migrate to new error types
     *bytes = &bytes[std::mem::size_of::<T>()..];
     Some(front)
 }


### PR DESCRIPTION
## Update zerocopy to v0.8.26

Updates zerocopy dependency and fixes breaking changes:
- `AsBytes` → `IntoBytes`
- `FromZeroes` → `FromZeros` 
- `read_from` → `read_from_bytes`
- Added `Immutable` derive for structs using `as_bytes()`

Resolves compilation errors from the dependency update.